### PR TITLE
Update Firestore rules for coach-only access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,13 +7,7 @@ service cloud.firestore {
       return request.auth != null;
     }
     
-    // Helper function to check if user is a member of a team
-    function isTeamMember(teamId) {
-      return isAuthenticated() && 
-        request.auth.uid in get(/databases/$(database)/documents/teams/$(teamId)).data.memberIds;
-    }
-    
-    // Helper function to check if user is the team owner
+    // Helper function to check if user is the team owner (coach)
     function isTeamOwner(teamId) {
       return isAuthenticated() &&
         get(/databases/$(database)/documents/teams/$(teamId)).data.ownerId == request.auth.uid;
@@ -21,61 +15,64 @@ service cloud.firestore {
 
     // Teams collection
     match /teams/{teamId} {
-      // Users can read teams they are members of
-      allow read: if isTeamMember(teamId);
-      
-      // Users can create teams (they become the owner)
-      allow create: if isAuthenticated() && 
-        request.resource.data.ownerId == request.auth.uid &&
-        request.auth.uid in request.resource.data.memberIds;
-      
+      // Only the coach (owner) can read the team
+      allow read: if isTeamOwner(teamId)
+        else error('permission-denied', 'Only the coach can access this team.');
+
+      // Coaches can create teams; they become the owner
+      allow create: if isAuthenticated() &&
+        request.resource.data.ownerId == request.auth.uid
+        else error('permission-denied', 'Only authenticated coaches can create teams.');
+
       // Only team owners can update team data
-      allow update: if isTeamOwner(teamId);
-      
+      allow update: if isTeamOwner(teamId)
+        else error('permission-denied', 'Only the coach can modify this team.');
+
       // Only team owners can delete teams
-      allow delete: if isTeamOwner(teamId);
+      allow delete: if isTeamOwner(teamId)
+        else error('permission-denied', 'Only the coach can delete this team.');
     }
 
     // Practice Plans collection
     match /practicePlans/{planId} {
-      // Users can read practice plans for teams they are members of
-      allow read: if isTeamMember(resource.data.teamId);
-      
-      // Users can create practice plans for teams they are members of
-      allow create: if isAuthenticated() && 
-        isTeamMember(request.resource.data.teamId) &&
-        request.resource.data.createdBy == request.auth.uid;
-      
-      // Users can update practice plans they created or if they are team owners
-      allow update: if isAuthenticated() && 
-        (resource.data.createdBy == request.auth.uid || 
-         isTeamOwner(resource.data.teamId));
-      
-      // Users can delete practice plans they created or if they are team owners
-      allow delete: if isAuthenticated() && 
-        (resource.data.createdBy == request.auth.uid || 
-         isTeamOwner(resource.data.teamId));
+      // Only the coach can read practice plans
+      allow read: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can view practice plans.');
+
+      // Only the coach can create practice plans
+      allow create: if isAuthenticated() &&
+        isTeamOwner(request.resource.data.teamId) &&
+        request.resource.data.createdBy == request.auth.uid
+        else error('permission-denied', 'Only the coach can create practice plans.');
+
+      // Only the coach can update practice plans
+      allow update: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can modify practice plans.');
+
+      // Only the coach can delete practice plans
+      allow delete: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can delete practice plans.');
     }
 
     // Plays collection
     match /plays/{playId} {
-      // Users can read plays for teams they are members of
-      allow read: if isTeamMember(resource.data.teamId);
-      
-      // Users can create plays for teams they are members of
-      allow create: if isAuthenticated() && 
-        isTeamMember(request.resource.data.teamId) &&
-        request.resource.data.createdBy == request.auth.uid;
-      
-      // Users can update plays they created or if they are team owners
-      allow update: if isAuthenticated() && 
-        (resource.data.createdBy == request.auth.uid || 
-         isTeamOwner(resource.data.teamId));
-      
-      // Users can delete plays they created or if they are team owners
-      allow delete: if isAuthenticated() && 
-        (resource.data.createdBy == request.auth.uid || 
-         isTeamOwner(resource.data.teamId));
+      // Only the coach can read plays
+      allow read: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can view plays.');
+
+      // Only the coach can create plays
+      allow create: if isAuthenticated() &&
+        isTeamOwner(request.resource.data.teamId) &&
+        request.resource.data.createdBy == request.auth.uid
+        else error('permission-denied', 'Only the coach can create plays.');
+
+      // Only the coach can update plays
+      allow update: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can modify plays.');
+
+      // Only the coach can delete plays
+      allow delete: if isTeamOwner(resource.data.teamId)
+        else error('permission-denied', 'Only the coach can delete plays.');
     }
   }
 }


### PR DESCRIPTION
## Summary
- limit Firestore access to the team owner (coach)
- add custom error messages to each rule

## Testing
- `python3 test_setup.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e2bbdf66c832da8d60497cf14b3e3