### PR TITLE
Secure Firebase config and add error boundary

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# Sample environment configuration for local development
+# Copy this file to `.env.local` and fill in your Firebase project details
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AIProvider } from './ai-brain/AIContext';
 import Dashboard from './components/Dashboard';
-import { ErrorBoundary } from './components/ErrorBoundary';
+import ErrorBoundary from './components/common/ErrorBoundary';
 import ToastManager from './components/ToastManager';
 import LoadingSpinner from './components/LoadingSpinner';
 import { AuthProvider } from './components/AuthProvider';
@@ -62,7 +62,9 @@ const App: React.FC = () => {
       case 'playbook':
         return (
           <React.Suspense fallback={<LoadingSpinner text="Loading Smart Playbook..." />}>
-            <SmartPlaybook />
+            <ErrorBoundary>
+              <SmartPlaybook />
+            </ErrorBoundary>
           </React.Suspense>
         );
       case 'test':

--- a/src/components/SmartPlaybook/SmartPlaybook.tsx
+++ b/src/components/SmartPlaybook/SmartPlaybook.tsx
@@ -11,7 +11,7 @@ import DebugPanel from './DebugPanel';
 import PlayLibrary from './PlayLibrary';
 import CanvasArea from './components/CanvasArea';
 import SavePlayDialog from './components/SavePlayDialog';
-import { ErrorBoundary } from '../ErrorBoundary';
+import ErrorBoundary from '../common/ErrorBoundary';
 import {
   createPlayer,
   createRoute,
@@ -571,14 +571,16 @@ const SmartPlaybook = () => {
             />
 
             {/* Route Editor */}
-            <RouteEditor
-              selectedRoute={routes.find(r => r.id === selectedRouteId)}
-              players={players}
-              onUpdateRoute={handleRouteUpdate}
-              onDeleteRoute={handleRouteDelete}
-              onApplyPreset={handleApplyPreset}
-              onClearSelection={() => setSelectedRouteId(null)}
-            />
+            <ErrorBoundary>
+              <RouteEditor
+                selectedRoute={routes.find(r => r.id === selectedRouteId)}
+                players={players}
+                onUpdateRoute={handleRouteUpdate}
+                onDeleteRoute={handleRouteDelete}
+                onApplyPreset={handleApplyPreset}
+                onClearSelection={() => setSelectedRouteId(null)}
+              />
+            </ErrorBoundary>
 
             {/* Save/Load Panel */}
             <SaveLoadPanel
@@ -596,13 +598,15 @@ const SmartPlaybook = () => {
 
           {/* Main Canvas Area */}
           <div className="lg:col-span-2">
-            <CanvasArea
-              canvasRef={canvasRef}
-              players={players}
-              routes={routes}
-              onCanvasEvent={handleCanvasEvent}
-              onPlayerDrag={handlePlayerDrag}
-            />
+            <ErrorBoundary>
+              <CanvasArea
+                canvasRef={canvasRef}
+                players={players}
+                routes={routes}
+                onCanvasEvent={handleCanvasEvent}
+                onPlayerDrag={handlePlayerDrag}
+              />
+            </ErrorBoundary>
 
             {/* Route Drawing Overlay */}
             {isDrawingRoute && routePoints.length > 0 && (

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<React.PropsWithChildren, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Error caught in ErrorBoundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h2>Something went wrong. Please refresh or try again later.</h2>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,27 +1,21 @@
-import { initializeApp } from 'firebase/app';
-// The following imports may cause errors if the Firebase modules are not installed or available.
-// To fix, ensure you have installed the required Firebase packages:
-// npm install firebase
-// If you only need certain services, you can comment out unused imports.
-
-import { getAuth, type Auth } from 'firebase/auth';
-import { getFirestore, type Firestore } from 'firebase/firestore';
-import { getAnalytics, type Analytics } from 'firebase/analytics';
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getAnalytics } from 'firebase/analytics';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyB2iWL0UkuLJYpr-II9IpwGWDOMnLcfq_c",
-  authDomain: "coach-core-ai.firebaseapp.com",
-  projectId: "coach-core-ai",
-  storageBucket: "coach-core-ai.appspot.com",
-  messagingSenderId: "384023691487",
-  appId: "1:384023691487:web:931094d7a0da903d6e696a",
-  measurementId: "G-02HW7QDJLY"
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
-const analytics = getAnalytics(app);
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
-export { app, auth, db, analytics }; 
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const analytics = getAnalytics(app);
+export default app;


### PR DESCRIPTION
## Summary
- secure firebase by moving config to env vars
- add basic ErrorBoundary component
- wrap SmartPlaybook, RouteEditor, and CanvasArea with the boundary
- include sample `.env.local.example`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821ffc845c832d90634d16da820a75